### PR TITLE
minor bugfixes, round numbers option & calculate height by angle

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,3 +177,4 @@ Make it as ugly as you want:
 | lineOpacity| 1 | number | Opacity of the lines |
 | numbersRadius| 17 | string | Change this to place the numbers closer or farther of the center. |
 | numbersFontSize| 19 | string | Font size of the number marks |
+| roundNumbers | false | boolean | Round the numbers in case of decimal value. |

--- a/README.md
+++ b/README.md
@@ -158,7 +158,8 @@ Make it as ugly as you want:
 | fontFamily | 'helvetica' | string | Font to use in the indicator and the marks. You need to configure in your project the font you want to use. |
 | indicatorSuffix | | string | Text to append to the indicator, for example 'k/h' or '%'. |
 | indicatorSuffixStyle | {} | object | Style applied to the suffix of the indicator. (You can reduce its font size to make it more cool). |
-
+| calcSizeByAngle | false | boolean | Calculate the component view by angle, usable when in case when component is square and the height calculated by backgroundAngle |
+| calcSizeByAngleIndicatorHeight | number | 0 | When calcSizeByAngle is used with bottom indicator, the indicator height must be added to total height | 
 
 ### Needle Options
 | Prop | Default | Type | Description |

--- a/src/Marks.js
+++ b/src/Marks.js
@@ -31,8 +31,11 @@ export default function Marks({
     lineColor = 'white',
     lineOpacity = 1,
     numbersRadius = 17,
-    numbersFontSize = 19
+    numbersFontSize = 19,
+    roundNumbers = true
   } = options
+
+  const getFormatedStepNumber = (val) => roundNumbers ? Math.round(val) : val;
 
   return(
     <>
@@ -73,7 +76,7 @@ export default function Marks({
                 opacity="0.8"
                 fontSize={numbersFontSize}
               >
-                {i * step}
+                {getFormatedStepNumber(i * step)}
               </Text>
             )}
           </G>

--- a/src/Needle.js
+++ b/src/Needle.js
@@ -34,6 +34,6 @@ export default function Needle ({center, options, accentColor}) {
   )
 }
 
-Needle.PropTypes = {
+Needle.propTypes = {
   center: PropTypes.number,
 }

--- a/src/Speedometer.js
+++ b/src/Speedometer.js
@@ -205,7 +205,7 @@ Speedometer.propTypes = {
   renderCap: PropTypes.func,
   max: PropTypes.number,
   noIndicator: PropTypes.bool,
-  backgroundColor: PropTypes.number,
+  backgroundColor: PropTypes.string,
   backgroundOpacity: PropTypes.number,
   step: PropTypes.number,
   marksFontFamily: PropTypes.string,
@@ -220,7 +220,7 @@ Speedometer.propTypes = {
   marks: PropTypes.object,
   noNumberMarks: PropTypes.bool,
   noBackground: PropTypes.bool,
-  indicatorSuffix: PropTypes.object,
+  indicatorSuffix: PropTypes.string,
   indicatorSuffixStyle: PropTypes.object,
   fontFamily: PropTypes.string,
   backgroundAngle: PropTypes.number

--- a/src/Speedometer.js
+++ b/src/Speedometer.js
@@ -49,7 +49,9 @@ export default function Speedometer({
   backgroundAngle = 360,
   fontFamily = 'helvetica',
   indicatorSuffix,
-  indicatorSuffixStyle = {}
+  indicatorSuffixStyle = {},
+  calcSizeByAngle = false,
+  calcSizeByAngleIndicatorHeight = 0
 }) {
 
   const radius = size / 2;
@@ -132,10 +134,14 @@ export default function Speedometer({
       />
     )
   }
+
+  const getViewHeight = () => calcSizeByAngle ? (size*(backgroundAngle/360)) + calcSizeByAngleIndicatorHeight : size;
+
+  const getSvgHeight = () =>  calcSizeByAngle ? (size*(backgroundAngle/360)) + 20 : size;
   
   return (
-    <View style={{width: size, height: size, marginRight: 25, ...style}}>
-      <Svg width={size} height={size}>
+    <View style={{width: size, height: getViewHeight(), marginRight: 25, ...style}}>
+      <Svg width={size} height={getSvgHeight()}>
         <G
           rotation={finalRotation}
           originX={radius}
@@ -223,5 +229,7 @@ Speedometer.propTypes = {
   indicatorSuffix: PropTypes.string,
   indicatorSuffixStyle: PropTypes.object,
   fontFamily: PropTypes.string,
-  backgroundAngle: PropTypes.number
+  backgroundAngle: PropTypes.number,
+  calcSizeByAngle: PropTypes.bool,
+  calcSizeByAngleIndicatorHeight: PropTypes.number
 };


### PR DESCRIPTION
1. When the max value updated from the state the mark numbers became decimal numbers, I added round number option to marks.
2. When I use debugger I found some type errors - fixed.
3. I use react-native-mac - and now its works great except 1 minor thing that i found a workaround for (i will fix it here later and will make PR)... I number set indicatorSuffixStyle like indicatorStyle to made it work. i think indicatorSuffixStyle need to extend indicatorStyle by default.
4. Added option to calculate the component height & svg height by background angle. In my case - when i set size its applys for height & width that created a square rect. with this option the height is calculated by the angle, ex: with angle of 180 the real height is half and not same as width.

Screenshot from react-native-mac:
https://i.imgur.com/BJ52Egh.png

Example of calculation by angle, the component inside a Card view:
https://imgur.com/3DoznKL
Same example without the calculation:
https://imgur.com/TYgWmxo

Thanks for your great work.. its rocks